### PR TITLE
perf: add preconnect/dns-prefetch and responsive sizes for images (mi…

### DIFF
--- a/web/src/app/blog/[slug]/page.tsx
+++ b/web/src/app/blog/[slug]/page.tsx
@@ -274,6 +274,7 @@ async function PostPage({ params }) {
             alt={post.coverImage.alt || 'Cover Image'}
             width={1200}
             height={630}
+            sizes="(min-width: 1024px) 1200px, 100vw"
             className="w-full rounded-lg mb-8"
             priority
           />

--- a/web/src/app/head.tsx
+++ b/web/src/app/head.tsx
@@ -1,0 +1,14 @@
+export default function Head() {
+  return (
+    <>
+      {/* Performance hints */}
+      <link rel="preconnect" href="https://cdn.sanity.io" crossOrigin="anonymous" />
+      <link rel="dns-prefetch" href="//cdn.sanity.io" />
+      <link rel="preconnect" href="https://www.googletagmanager.com" crossOrigin="anonymous" />
+      <link rel="dns-prefetch" href="//www.googletagmanager.com" />
+      <link rel="preconnect" href="https://www.google-analytics.com" crossOrigin="anonymous" />
+      <link rel="dns-prefetch" href="//www.google-analytics.com" />
+    </>
+  )
+}
+

--- a/web/src/components/PostBody.tsx
+++ b/web/src/components/PostBody.tsx
@@ -8,18 +8,21 @@ const slugger = new Slugger()
 
 const components: PortableTextComponents = {
   types: {
-    image: ({ value }: { value: any }) => {
-      return (
-        <div className="relative w-full h-96 my-8">
-          <Image
-            className="object-contain"
-            src={urlFor(value).url()}
-            alt={value.alt || 'Blog Post Image'}
-            fill
-          />
-        </div>
-      )
-    },
+      image: ({ value }: { value: any }) => {
+        return (
+          <div className="relative w-full h-96 my-8">
+            <Image
+              className="object-contain"
+              src={urlFor(value).url()}
+              alt={value.alt || 'Blog Post Image'}
+              fill
+              sizes="(min-width: 1024px) 768px, 100vw"
+              loading="lazy"
+              decoding="async"
+            />
+          </div>
+        )
+      },
   },
   block: {
     h1: (props: PortableTextComponentProps<PortableTextBlock>) => {


### PR DESCRIPTION
- 変更点（最小差分）
      - web/src/app/head.tsx: preconnect/dns-prefetch 追加
      - cdn.sanity.io / googletagmanager.com / google-analytics.com
  - web/src/app/blog/[slug]/page.tsx: カバー画像に sizes="(min-width: 1024px) 1200px, 100vw" 付与
  - web/src/components/PostBody.tsx: 本文画像に sizes/loading="lazy"/decoding="async" 付与