### PR TITLE
chore(seo/meta): clamp descriptions; add twitter:image:alt; add robot…

### DIFF
--- a/web/src/app/blog/category/[category]/page.tsx
+++ b/web/src/app/blog/category/[category]/page.tsx
@@ -25,16 +25,22 @@ export async function generateMetadata({ params }): Promise<Metadata> {
   const siteUrl = getSiteUrl();
   const ogImageUrl = new URL('/og', siteUrl)
   ogImageUrl.searchParams.set('title', `カテゴリ: ${title}`)
+  const clamp = (t?: string) => {
+    if (!t) return undefined
+    const s = String(t).replace(/\s+/g, ' ').trim()
+    return s.length > 160 ? s.slice(0,157) + '…' : s
+  }
+  const desc = `カテゴリ「${title}」の記事一覧（最新順）です。`
   return {
     title: `カテゴリ「${title}」の記事`,
-    description: `カテゴリ「${title}」に属する記事一覧です。最新順に表示しています。`,
+    description: clamp(desc),
     alternates: { canonical: `${siteUrl}/blog/category/${params.category}` },
     robots: { index: true, follow: true },
     openGraph: {
       type: 'website',
       url: `${siteUrl}/blog/category/${params.category}`,
       title: `カテゴリ「${title}」の記事`,
-      description: `カテゴリ「${title}」に属する記事一覧です。`,
+      description: desc,
       images: [
         { url: ogImageUrl.toString(), width: 1200, height: 630, alt: `カテゴリ: ${title}` },
       ],
@@ -42,8 +48,11 @@ export async function generateMetadata({ params }): Promise<Metadata> {
     twitter: {
       card: 'summary_large_image',
       title: `カテゴリ「${title}」の記事`,
-      description: `カテゴリ「${title}」に属する記事一覧です。`,
+      description: desc,
       images: [ogImageUrl.toString()],
+    },
+    other: {
+      'twitter:image:alt': `カテゴリ: ${title}`,
     },
   };
 }
@@ -98,13 +107,13 @@ async function CategoryPage({ params }) {
       {
         '@type': 'ListItem',
         position: 1,
-        name: 'Home',
+        name: 'ホーム',
         item: siteUrl,
       },
       {
         '@type': 'ListItem',
         position: 2,
-        name: 'Blog',
+        name: 'ブログ',
         item: `${siteUrl}/blog`,
       },
       {

--- a/web/src/app/blog/category/[category]/page/[page]/page.tsx
+++ b/web/src/app/blog/category/[category]/page/[page]/page.tsx
@@ -32,16 +32,22 @@ export async function generateMetadata({ params }: { params: { category: string;
   const pageNum = Number(params.page) || 1
   const ogImageUrl = new URL('/og', siteUrl)
   ogImageUrl.searchParams.set('title', `カテゴリ: ${title} - ページ ${pageNum}`)
+  const desc = `カテゴリ「${title}」の記事一覧（最新順） - ページ ${pageNum} です。`
+  const clamp = (t?: string) => {
+    if (!t) return undefined
+    const s = t.replace(/\s+/g, ' ').trim()
+    return s.length > 160 ? s.slice(0,157) + '…' : s
+  }
   return {
     title: `カテゴリ「${title}」の記事 - ページ ${pageNum}`,
-    description: `カテゴリ「${title}」に属する記事の ${pageNum} ページ目です。`,
+    description: clamp(desc),
     alternates: { canonical: `${siteUrl}/blog/category/${params.category}/page/${pageNum}` },
     robots: { index: true, follow: true },
     openGraph: {
       type: 'website',
       url: `${siteUrl}/blog/category/${params.category}/page/${pageNum}`,
       title: `カテゴリ「${title}」の記事 - ページ ${pageNum}`,
-      description: `カテゴリ「${title}」に属する記事の ${pageNum} ページ目です。`,
+      description: desc,
       images: [
         { url: ogImageUrl.toString(), width: 1200, height: 630, alt: `カテゴリ: ${title} - ページ ${pageNum}` },
       ],
@@ -49,8 +55,11 @@ export async function generateMetadata({ params }: { params: { category: string;
     twitter: {
       card: 'summary_large_image',
       title: `カテゴリ「${title}」の記事 - ページ ${pageNum}`,
-      description: `カテゴリ「${title}」に属する記事の ${pageNum} ページ目です。`,
+      description: desc,
       images: [ogImageUrl.toString()],
+    },
+    other: {
+      'twitter:image:alt': `カテゴリ: ${title} - ページ ${pageNum}`,
     },
   }
 }

--- a/web/src/app/blog/page.tsx
+++ b/web/src/app/blog/page.tsx
@@ -12,11 +12,16 @@ export async function generateMetadata(): Promise<Metadata> {
   const siteUrl = getSiteUrl()
   const title = 'すべての記事'
   const description = '最新の記事一覧とカテゴリ・タグでの絞り込みができます。'
+  const clamp = (t?: string) => {
+    if (!t) return undefined
+    const s = t.replace(/\s+/g, ' ').trim()
+    return s.length > 160 ? s.slice(0,157) + '…' : s
+  }
   const ogImageUrl = new URL('/og', siteUrl)
   ogImageUrl.searchParams.set('title', title)
   return {
     title,
-    description,
+    description: clamp(description),
     alternates: { canonical: `${siteUrl}/blog` },
     robots: { index: true, follow: true },
     openGraph: {
@@ -33,6 +38,9 @@ export async function generateMetadata(): Promise<Metadata> {
       title,
       description,
       images: [ogImageUrl.toString()],
+    },
+    other: {
+      'twitter:image:alt': title,
     },
   }
 }
@@ -80,8 +88,8 @@ export default async function Page({ searchParams }: { searchParams?: { category
             '@context': 'https://schema.org',
             '@type': 'BreadcrumbList',
             itemListElement: [
-              { '@type': 'ListItem', position: 1, name: 'Home', item: getSiteUrl() },
-              { '@type': 'ListItem', position: 2, name: 'Blog', item: `${getSiteUrl()}/blog` },
+              { '@type': 'ListItem', position: 1, name: 'ホーム', item: getSiteUrl() },
+              { '@type': 'ListItem', position: 2, name: 'ブログ', item: `${getSiteUrl()}/blog` },
             ],
           }) }}
         />

--- a/web/src/app/blog/page/[page]/page.tsx
+++ b/web/src/app/blog/page/[page]/page.tsx
@@ -22,10 +22,17 @@ export async function generateMetadata({ params }: { params: { page: string } })
   const siteUrl = getSiteUrl()
   const pageNum = Number(params.page) || 1
   const title = `すべての記事 - ページ ${pageNum}`
+  const description = `すべての記事のページ ${pageNum} の記事一覧ページです。`
+  const clamp = (t?: string) => {
+    if (!t) return undefined
+    const s = t.replace(/\s+/g, ' ').trim()
+    return s.length > 160 ? s.slice(0,157) + '…' : s
+  }
   const ogImageUrl = new URL('/og', siteUrl)
   ogImageUrl.searchParams.set('title', title)
   return {
     title,
+    description: clamp(description),
     alternates: {
       canonical: pageNum === 1 ? `${siteUrl}/blog` : `${siteUrl}/blog/page/${pageNum}`,
     },
@@ -42,6 +49,9 @@ export async function generateMetadata({ params }: { params: { page: string } })
       card: 'summary_large_image',
       title,
       images: [ogImageUrl.toString()],
+    },
+    other: {
+      'twitter:image:alt': title,
     },
   }
 }

--- a/web/src/app/blog/tag/[tag]/page.tsx
+++ b/web/src/app/blog/tag/[tag]/page.tsx
@@ -25,16 +25,22 @@ export async function generateMetadata({ params }): Promise<Metadata> {
   const siteUrl = getSiteUrl();
   const ogImageUrl = new URL('/og', siteUrl)
   ogImageUrl.searchParams.set('title', `タグ: ${title}`)
+  const clamp = (t?: string) => {
+    if (!t) return undefined
+    const s = String(t).replace(/\s+/g, ' ').trim()
+    return s.length > 160 ? s.slice(0,157) + '…' : s
+  }
+  const desc = `タグ「${title}」の記事一覧（最新順）です。`
   return {
     title: `タグ「${title}」の記事`,
-    description: `タグ「${title}」が付いた記事一覧です。最新順に表示しています。`,
+    description: clamp(desc),
     alternates: { canonical: `${siteUrl}/blog/tag/${params.tag}` },
     robots: { index: true, follow: true },
     openGraph: {
       type: 'website',
       url: `${siteUrl}/blog/tag/${params.tag}`,
       title: `タグ「${title}」の記事`,
-      description: `タグ「${title}」が付いた記事一覧です。`,
+      description: desc,
       images: [
         { url: ogImageUrl.toString(), width: 1200, height: 630, alt: `タグ: ${title}` },
       ],
@@ -42,8 +48,11 @@ export async function generateMetadata({ params }): Promise<Metadata> {
     twitter: {
       card: 'summary_large_image',
       title: `タグ「${title}」の記事`,
-      description: `タグ「${title}」が付いた記事一覧です。`,
+      description: desc,
       images: [ogImageUrl.toString()],
+    },
+    other: {
+      'twitter:image:alt': `タグ: ${title}`,
     },
   };
 }
@@ -97,19 +106,19 @@ async function TagPage({ params }) {
       {
         '@type': 'ListItem',
         position: 1,
-        name: 'Home',
+        name: 'ホーム',
         item: siteUrl,
       },
       {
         '@type': 'ListItem',
         position: 2,
-        name: 'Blog',
+        name: 'ブログ',
         item: `${siteUrl}/blog`,
       },
       {
         '@type': 'ListItem',
         position: 3,
-        name: `Posts tagged: ${tag.title}`,
+        name: `タグ: ${tag.title}`,
         item: `${siteUrl}/blog/tag/${tag.slug.current}`,
       },
     ],

--- a/web/src/app/blog/tag/[tag]/page/[page]/page.tsx
+++ b/web/src/app/blog/tag/[tag]/page/[page]/page.tsx
@@ -36,16 +36,22 @@ export async function generateMetadata({ params }: { params: { tag: string; page
   const pageNum = Number(params.page) || 1
   const ogImageUrl = new URL('/og', siteUrl)
   ogImageUrl.searchParams.set('title', `タグ: ${title} - ページ ${pageNum}`)
+  const desc = `タグ「${title}」の記事一覧（最新順） - ページ ${pageNum} です。`
+  const clamp = (t?: string) => {
+    if (!t) return undefined
+    const s = t.replace(/\s+/g, ' ').trim()
+    return s.length > 160 ? s.slice(0,157) + '…' : s
+  }
   return {
     title: `タグ「${title}」の記事 - ページ ${pageNum}`,
-    description: `タグ「${title}」が付いた記事の ${pageNum} ページ目です。`,
+    description: clamp(desc),
     alternates: { canonical: `${siteUrl}/blog/tag/${params.tag}/page/${pageNum}` },
     robots: { index: true, follow: true },
     openGraph: {
       type: 'website',
       url: `${siteUrl}/blog/tag/${params.tag}/page/${pageNum}`,
       title: `タグ「${title}」の記事 - ページ ${pageNum}`,
-      description: `タグ「${title}」が付いた記事の ${pageNum} ページ目です。`,
+      description: desc,
       images: [
         { url: ogImageUrl.toString(), width: 1200, height: 630, alt: `タグ: ${title} - ページ ${pageNum}` },
       ],
@@ -53,8 +59,11 @@ export async function generateMetadata({ params }: { params: { tag: string; page
     twitter: {
       card: 'summary_large_image',
       title: `タグ「${title}」の記事 - ページ ${pageNum}`,
-      description: `タグ「${title}」が付いた記事の ${pageNum} ページ目です。`,
+      description: desc,
       images: [ogImageUrl.toString()],
+    },
+    other: {
+      'twitter:image:alt': `タグ: ${title} - ページ ${pageNum}`,
     },
   }
 }

--- a/web/src/app/layout.tsx
+++ b/web/src/app/layout.tsx
@@ -40,6 +40,12 @@ export async function generateMetadata(): Promise<Metadata> {
     robots: {
       index: !!isProd,
       follow: !!isProd,
+      // Improve image preview snippets on Google
+      googleBot: {
+        index: !!isProd,
+        follow: !!isProd,
+        'max-image-preview': 'large',
+      },
     },
     openGraph: {
       type: 'website',

--- a/web/src/app/search/page.tsx
+++ b/web/src/app/search/page.tsx
@@ -1,9 +1,21 @@
 // apps/web/app/search/page.tsx（動的importでバンドル分割）
 import dynamic from 'next/dynamic'
+import type { Metadata } from 'next'
+import { getSiteUrl } from '@/lib/site'
 
-export const metadata = {
-  title: '検索',
-  robots: { index: false, follow: true },
+export async function generateMetadata({ searchParams }: { searchParams?: { q?: string } }): Promise<Metadata> {
+  const q = (searchParams?.q || '').trim()
+  const siteUrl = getSiteUrl()
+  const title = q ? `検索: ${q}` : '検索'
+  const description = q
+    ? `「${q}」の検索結果ページです。該当がない場合はキーワードを変えて再検索できます。`
+    : 'ブログ内検索ページです。キーワードを入力して記事を探せます。'
+  return {
+    title,
+    description,
+    robots: { index: false, follow: true },
+    alternates: { canonical: `${siteUrl}/search${q ? `?q=${encodeURIComponent(q)}` : ''}` },
+  }
 }
 
 const ClientSearch = dynamic(() => import('@/components/search/ClientSearch'), {
@@ -12,6 +24,26 @@ const ClientSearch = dynamic(() => import('@/components/search/ClientSearch'), {
 })
 
 export default function Page({ searchParams }: { searchParams: { q?: string } }) {
-  const q = searchParams?.q ?? ''
-  return <ClientSearch initialQuery={q} />
+  const q = (searchParams?.q || '').trim()
+  const siteUrl = getSiteUrl()
+  const ld = q
+    ? {
+        '@context': 'https://schema.org',
+        '@type': 'SearchResultsPage',
+        name: `検索: ${q}`,
+        mainEntity: {
+          '@type': 'SearchAction',
+          target: `${siteUrl}/search?q={search_term_string}`,
+          'query-input': 'required name=search_term_string',
+        },
+      }
+    : null
+  return (
+    <>
+      {ld && (
+        <script type="application/ld+json" dangerouslySetInnerHTML={{ __html: JSON.stringify(ld) }} />
+      )}
+      <ClientSearch initialQuery={q} />
+    </>
+  )
 }


### PR DESCRIPTION
…s max-image-preview; speakable; JP breadcrumbs; search metadata; docs: progress update
- 変更: robots拡張、各種descriptionクランプ、twitter:image:alt、speakable、BreadcrumbラベルJP、検索ページmetadata、進捗ドキュメント